### PR TITLE
Fixing non-blind SQL Injection

### DIFF
--- a/classes/PDOV/Connection.php
+++ b/classes/PDOV/Connection.php
@@ -205,6 +205,7 @@ class Connection extends \PHPixie\DB\Connection {
         }
 
         $this->isBlinded = false;
+	$this->pixie->debug->display_errors = true; 	// FIX SQLi
     }
 
     public function stopBlindness()


### PR DESCRIPTION
See also https://github.com/rapid7/hackazon/issues/1 and https://github.com/rapid7/hackazon/issues/1#issuecomment-257025046.

All SQL injections are blind in the current Hackazon--no "SQL Syntax Error" message appears.  This commit fixes that problem by adding one line of code, as detailed below. 

In ./classes/PDOV/Connection.php, at the end of the startBlindness function,
after line 207, add this line:

```
    $this->pixie->debug->display_errors = true;     // FIX SQLi
```

The resulting startBlindness function looks like this:

---

```
public function startBlindness($vulnFields)
{
    if (!$vulnFields || $this->vulnerable) {
        return;
    }

    if (!is_array($vulnFields) && !($vulnFields instanceof \ArrayObject)) {
        $vulnFields = [$vulnFields];
    }

    $this->vulnerable = false;

    foreach ($vulnFields as $field) {
        if (!($field instanceof VulnerableField)) {
            continue;
        }

        if ($field->isVulnerableTo('SQL')) {
            $this->vulnerable = true;
            if ($field->getVulnerability('SQL')->isBlind()) {
                $this->dispErrorStates[] = $this->pixie->debug->display_errors;
                $this->pixie->debug->display_errors = false;
                $this->isBlinded = true;
                return;
            }
        }
    }

    $this->isBlinded = false;
    $this->pixie->debug->display_errors = true;   // FIX SQLi
}
```

---
