### PR TITLE
Graceful basic auth

### DIFF
--- a/classes/App/Rest/Auth/Provider.php
+++ b/classes/App/Rest/Auth/Provider.php
@@ -42,13 +42,14 @@ abstract class Provider
 
     protected function requireBasicCredentials()
     {
-        $headers = getallheaders();
+        // Ensure headers are lower-case
+        $headers = array_change_key_case(getallheaders());
 
-        if (!$headers['Authorization'] || strpos($headers['Authorization'], 'Basic ') !== 0) {
+        if (!$headers['authorization'] || strpos($headers['authorization'], 'Basic ') !== 0) {
             $this->askForBasicCredentials();
         }
 
-        $parts = preg_split('/\s+/', $headers['Authorization'], 2, PREG_SPLIT_NO_EMPTY);
+        $parts = preg_split('/\s+/', $headers['authorization'], 2, PREG_SPLIT_NO_EMPTY);
         $credentials = explode(':', base64_decode($parts[1]));
         $username = $credentials[0];
         $password = $credentials[1];
@@ -73,7 +74,7 @@ abstract class Provider
 
     protected function askForBasicCredentials($realm = "Provide your credentials.", $authMethod = "Basic")
     {
-        header('WWW-Authenticate: '.$authMethod.' realm="'.$realm.'"');
+        header('WWW-authenticate: '.$authMethod.' realm="'.$realm.'"');
         header('HTTP/1.1 401 Unauthorized', true, 401);
         exit;
     }

--- a/classes/App/Rest/Auth/Provider.php
+++ b/classes/App/Rest/Auth/Provider.php
@@ -74,7 +74,7 @@ abstract class Provider
 
     protected function askForBasicCredentials($realm = "Provide your credentials.", $authMethod = "Basic")
     {
-        header('WWW-authenticate: '.$authMethod.' realm="'.$realm.'"');
+        header('WWW-Authenticate: '.$authMethod.' realm="'.$realm.'"');
         header('HTTP/1.1 401 Unauthorized', true, 401);
         exit;
     }


### PR DESCRIPTION
While HTTP headers are case-insensitive, the Hackazon site does not appear to respect that when dealing with the `Authorization` header.

The `/api/auth` endpoint uses Basic Authentication and has apparently always worked.  I cannot find anything that has changed that could have broken this.  This code change removes any potential ambiguity around the case of the Authorization header - it is forced to lowercase and parsed as such.

Now either of these scenarios will work:

`Authorization: Basic <base64-encoded credentials>`
`authorization: Basic <base64-encoded credentials>`